### PR TITLE
H5区服老乞丐提醒改用 QQ 推送

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -12,35 +12,48 @@ import (
 	"fmt"
 	"github.com/robfig/cron/v3"
 	"github.com/spf13/viper"
-	"github.com/wxpusher/wxpusher-sdk-go"
-	"github.com/wxpusher/wxpusher-sdk-go/model"
 	"log"
+	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
 //go:embed config
 var f embed.FS
+var jobMu sync.Mutex
 
 func init() {
 	global.ConfigFile, _ = f.ReadFile("config/config.yaml")
 	global.Item, _ = f.ReadFile("config/Item.json")
 	global.ItemToName, _ = f.ReadFile("config/ItemToName.json")
+}
 
-	err := D1()
-	if err != nil {
-		log.Println(err)
-		return
+func bootstrap() error {
+	if err := D1(); err != nil {
+		return err
 	}
-	err = _No()
-	if err != nil {
-		log.Println(err)
-		return
+	if err := _No(); err != nil {
+		return err
 	}
-	err = D30()
-	if err != nil {
+	if time.Now().Hour() < 8 {
+		return nil
+	}
+	if err := D30(); err != nil {
 		log.Println(err)
-		return
+	}
+	return nil
+}
+
+func runExclusive(fn func() error) error {
+	jobMu.Lock()
+	defer jobMu.Unlock()
+	return fn()
+}
+
+func rememberFirstErr(firstErr *error, err error) {
+	if *firstErr == nil {
+		*firstErr = err
 	}
 }
 
@@ -129,34 +142,61 @@ func D1() error {
 }
 
 func D30() error {
+	var firstErr error
 	for _, v := range global.LoginStructList {
 		if v.IsOver {
 			continue
 		}
 		ItemData, err := GetShopData(v)
 		if err != nil {
-			return err
+			err = fmt.Errorf("server %s get shop data: %w", v.ServerCode, err)
+			log.Println("[-]", err)
+			rememberFirstErr(&firstErr, err)
+			continue
 		}
 		if ItemData != nil {
 			log.Println("[+] 老乞丐售卖物品:", ItemData, "当前区服:", v.ServerCode)
-			msg := model.NewMessage(global.WX_APPTOKEN)
-			msg.Summary = fmt.Sprintf("老乞丐提醒-%s", v.ServerCode)
-			msg.SetContent((strings.Join(ItemData[:], ","))).AddTopicId(WxTopicid(v.ServerCode))
-			msgArr, err := wxpusher.SendMessage(msg)
-			log.Println("[+] 微信通道状态:", msgArr, err)
+			content := strings.Join(ItemData[:], ",")
+			if os.Getenv("DRY_RUN") == "1" {
+				log.Println("[DRY_RUN] skip qq push:", "server:", v.ServerCode, "content:", content)
+				v.IsOver = true
+				continue
+			}
+			summary := fmt.Sprintf("HerosTime old beggar reminder-%s", v.ServerCode)
+			err = SendQQMessage(v.ServerCode, summary, content)
+			for retry := 1; err != nil && retry <= 3; retry++ {
+				log.Println("[-] QQ push failed:", err, "retry:", retry)
+				time.Sleep(2 * time.Second)
+				err = SendQQMessage(v.ServerCode, summary, content)
+			}
+			log.Println("[+] QQ push status:", err)
 			if err != nil {
-				for true {
-					log.Println("[-] 微信通道失败:", err, " 2秒后重新尝试发送.")
-					time.Sleep(2 * time.Second)
-					msgArr2, err2 := wxpusher.SendMessage(msg)
-					log.Println("[+] 微信通道状态:", msgArr2)
-					if err2 == nil {
-						break
-					}
-				}
+				err = fmt.Errorf("server %s qq push: %w", v.ServerCode, err)
+				log.Println("[-]", err)
+				rememberFirstErr(&firstErr, err)
+				continue
 			}
 			v.IsOver = true
 		}
+	}
+	return firstErr
+}
+
+func SendSelfCheckMonitor() error {
+	content := fmt.Sprintf("服务: h5\n状态: 自检完成\n时间: %s\n正式检测: 08:00 开始", time.Now().Format("2006-01-02 15:04:05"))
+	if os.Getenv("DRY_RUN") == "1" {
+		log.Println("[DRY_RUN] skip self-check qq push:", content)
+		return nil
+	}
+	err := SendQQMessage("monitor", "老乞丐推送程序自检完成-h5", content)
+	for retry := 1; err != nil && retry <= 3; retry++ {
+		log.Println("[-] self-check QQ push failed:", err, "retry:", retry)
+		time.Sleep(2 * time.Second)
+		err = SendQQMessage("monitor", "老乞丐推送程序自检完成-h5", content)
+	}
+	log.Println("[+] self-check QQ push status:", err)
+	if err != nil {
+		return fmt.Errorf("self-check qq push: %w", err)
 	}
 	return nil
 }
@@ -180,18 +220,24 @@ func _No() error {
 }
 
 func Run() {
-	c := cron.New(cron.WithSeconds())
-	//早上查询福缘值
-	_, _ = c.AddFunc("0 30 7 * * *", func() { //01 * * * *
-		err := D1()
+	if err := runExclusive(bootstrap); err != nil {
+		log.Fatal(err)
+	}
+
+	c := cron.New(cron.WithSeconds(), cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
+	_, _ = c.AddFunc("0 30 7 * * *", func() {
+		err := runExclusive(func() error {
+			if err := D1(); err != nil {
+				return err
+			}
+			return SendSelfCheckMonitor()
+		})
 		if err != nil {
 			log.Println(err)
 		}
 	})
-	//半小时查询
-	_, _ = c.AddFunc("30 0,30 * * * *", func() { //30 0,30 * * * *
-		err := D30()
-		if err != nil {
+	_, _ = c.AddFunc("30 0,30 8-23 * * *", func() {
+		if err := runExclusive(D30); err != nil {
 			log.Println(err)
 		}
 	})

--- a/app/config/config.yaml
+++ b/app/config/config.yaml
@@ -1,4 +1,4 @@
-#项目配置文件
+﻿#项目配置文件
 #当前在用
 
 # 数据库配置
@@ -38,6 +38,24 @@
   "h5_9":
     "username": "4399madhero"
     "password": "1qaz@WSX"
+  "h5_10":
+    "username": "4399madhero"
+    "password": "1qaz@WSX"
+  "h5_11":
+    "username": "4399madhero"
+    "password": "1qaz@WSX"
+  "h5_12":
+    "username": "4399madhero"
+    "password": "1qaz@WSX"
+  "h5_13":
+    "username": "4399madhero"
+    "password": "1qaz@WSX"
+  "h5_14":
+    "username": "4399madhero"
+    "password": "1qaz@WSX"
+  "h5_15":
+    "username": "4399madhero"
+    "password": "1qaz@WSX"
 
 #微信推送配置
 "WX_APPTOKEN": "AT_vYeuEDdRy41tuBxjfoN22MS1eudEMAF8"
@@ -51,3 +69,8 @@
   "h5_7": !!int '2954'
   "h5_8": !!int '4034'
   "h5_9": !!int '6491'
+  "h5_10": !!int '39127'
+  "h5_11": !!int '39128'
+  "h5_12": !!int '39129'
+  "h5_13": !!int '39130'
+  "h5_14": !!int '39131'

--- a/app/push_qq.go
+++ b/app/push_qq.go
@@ -1,0 +1,183 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func SendQQMessage(serverCode, summary, content string) error {
+	apiURL := strings.TrimRight(strings.TrimSpace(os.Getenv("QQ_BOT_API_URL")), "/")
+	if apiURL == "" {
+		return errors.New("QQ_BOT_API_URL is required")
+	}
+
+	endpoint, idKey, id, err := qqTarget(serverCode)
+	if err != nil {
+		return err
+	}
+
+	message := strings.TrimSpace(summary)
+	if content != "" {
+		if message != "" {
+			message += "\n"
+		}
+		message += content
+	}
+
+	payload := map[string]interface{}{
+		idKey:     id,
+		"message": message,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, apiURL+endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token := strings.TrimSpace(os.Getenv("QQ_BOT_ACCESS_TOKEN")); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("qq push http status %d: %s", resp.StatusCode, trimBody(respBody))
+	}
+
+	var result struct {
+		Status  string `json:"status"`
+		Retcode int    `json:"retcode"`
+		Msg     string `json:"msg"`
+		Wording string `json:"wording"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return fmt.Errorf("qq push response decode failed: %w body=%s", err, trimBody(respBody))
+	}
+	if result.Retcode != 0 || (result.Status != "" && strings.ToLower(result.Status) != "ok") {
+		return fmt.Errorf("qq push failed: status=%s retcode=%d msg=%s wording=%s", result.Status, result.Retcode, result.Msg, result.Wording)
+	}
+	return nil
+}
+
+func qqTarget(serverCode string) (string, string, int64, error) {
+	targetType := strings.ToLower(strings.TrimSpace(os.Getenv("QQ_TARGET_TYPE")))
+	if targetType == "" {
+		targetType = "group"
+	}
+
+	targetID := strings.TrimSpace(os.Getenv("QQ_TARGET_ID"))
+	endpoint := "/send_group_msg"
+	idKey := "group_id"
+
+	switch targetType {
+	case "group":
+		targetID = qqGroupID(serverCode)
+	case "private", "user", "friend":
+		endpoint = "/send_private_msg"
+		idKey = "user_id"
+		if targetID == "" {
+			targetID = strings.TrimSpace(os.Getenv("QQ_USER_ID"))
+		}
+	default:
+		return "", "", 0, fmt.Errorf("unsupported QQ_TARGET_TYPE: %s", targetType)
+	}
+
+	if targetID == "" {
+		if targetType == "group" {
+			return "", "", 0, fmt.Errorf("QQ group id is required for server %s; set QQ_GROUP_ID_%s, QQ_GROUP_MAP, QQ_GROUP_MAP_FILE, or QQ_GROUP_ID", serverCode, envServerCode(serverCode))
+		}
+		return "", "", 0, errors.New("QQ target id is required")
+	}
+	id, err := strconv.ParseInt(targetID, 10, 64)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid QQ target id %q: %w", targetID, err)
+	}
+	return endpoint, idKey, id, nil
+}
+
+func qqGroupID(serverCode string) string {
+	if id := strings.TrimSpace(os.Getenv("QQ_GROUP_ID_" + envServerCode(serverCode))); id != "" {
+		return id
+	}
+	if id, err := qqGroupIDFromJSON(strings.TrimSpace(os.Getenv("QQ_GROUP_MAP")), serverCode); err == nil && id != "" {
+		return id
+	}
+	if mapFile := strings.TrimSpace(os.Getenv("QQ_GROUP_MAP_FILE")); mapFile != "" {
+		if raw, err := os.ReadFile(mapFile); err == nil {
+			if id, err := qqGroupIDFromJSON(string(raw), serverCode); err == nil && id != "" {
+				return id
+			}
+		}
+	}
+	if id := strings.TrimSpace(os.Getenv("QQ_TARGET_ID")); id != "" {
+		return id
+	}
+	return strings.TrimSpace(os.Getenv("QQ_GROUP_ID"))
+}
+
+func qqGroupIDFromJSON(raw, serverCode string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+
+	var groups map[string]interface{}
+	if err := decoder.Decode(&groups); err != nil {
+		return "", err
+	}
+	for key, value := range groups {
+		if key != serverCode && !strings.EqualFold(key, serverCode) {
+			continue
+		}
+		switch v := value.(type) {
+		case string:
+			return strings.TrimSpace(v), nil
+		case json.Number:
+			return v.String(), nil
+		case float64:
+			return strconv.FormatInt(int64(v), 10), nil
+		default:
+			return "", fmt.Errorf("unsupported QQ group id value for %s", serverCode)
+		}
+	}
+	return "", nil
+}
+
+func envServerCode(serverCode string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(serverCode) {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	return b.String()
+}
+
+func trimBody(body []byte) string {
+	text := strings.TrimSpace(string(body))
+	if len(text) > 300 {
+		return text[:300]
+	}
+	return text
+}

--- a/cmd/listservers/main.go
+++ b/cmd/listservers/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"HerosTime/loginutil"
+)
+
+func main() {
+	if err := loginutil.GetServerList(); err != nil {
+		panic(err)
+	}
+	first := true
+	for i := 1; i <= 80; i++ {
+		code := fmt.Sprintf("h5_%d", i)
+		if _, _, err := loginutil.ChooseServer(code); err == nil {
+			if !first {
+				fmt.Print(",")
+			}
+			fmt.Print(code)
+			first = false
+		}
+	}
+	fmt.Println()
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,5 @@ require (
 	github.com/mojocn/base64Captcha v1.2.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.8.1
-	github.com/wxpusher/wxpusher-sdk-go v1.0.3
 	github.com/zc2638/go-standard v0.0.0-20210328074404-6a9e4c40ee58
 )

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/wxpusher/wxpusher-sdk-go v1.0.3 h1:KMI7yYhPps5AbiI5X2d24v0l+D/0Kzm4iiCyWBlWSKE=
-github.com/wxpusher/wxpusher-sdk-go v1.0.3/go.mod h1:OfMYzFcCUNECO0ycmjCUciKD1PG67LBWeMC9B1KtBnE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/loginutil/chooseServer.go
+++ b/loginutil/chooseServer.go
@@ -1,12 +1,9 @@
-/**
-* @Author: Ramoncjs
-* @Date: 2021/8/20 21:03
- */
 package loginutil
 
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 type urlStruct struct {
@@ -14,48 +11,73 @@ type urlStruct struct {
 	GameUrl       string
 }
 
+var srv map[string]interface{}
+var rt = make(map[string]urlStruct)
+
 type BZSRVLIST map[string][]string
 
 var bsvrlst BZSRVLIST
 
-var srv map[string]interface{}
-var rt = make(map[string]urlStruct)
-
 func ChooseServer(servercode string) (string, string, error) {
-	for k, v := range srv {
-		switch v.([]interface{})[5].(string) {
-
-		case "h5暴走1区":
-			rt["h5_1"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走2区":
-			rt["h5_2"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走3区":
-			rt["h5_3"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走4区":
-			rt["h5_4"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走5区":
-			rt["h5_5"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走6区":
-			rt["h5_6"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走7区":
-			rt["h5_7"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走8区":
-			rt["h5_8"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		case "h5暴走9区":
-			rt["h5_9"] = urlStruct{QuickLoginUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[2].(string)), GameUrl: fmt.Sprintf("%s:%s", bsvrlst[k][0], v.([]interface{})[3].(string))}
-
-		default:
-			return "", "", errors.New("[-] 区服代码错误.")
+	rt = make(map[string]urlStruct)
+	for _, raw := range srv {
+		entry, ok := raw.([]interface{})
+		if !ok || len(entry) < 6 {
+			continue
+		}
+		name, _ := entry[5].(string)
+		if !strings.HasPrefix(strings.ToLower(name), "h5") {
+			continue
+		}
+		n := zoneNumber(name)
+		if n <= 0 {
+			continue
+		}
+		rt[fmt.Sprintf("h5_%d", n)] = urlStruct{
+			QuickLoginUrl: serverURL(entry, 2),
+			GameUrl:       serverURL(entry, 3),
 		}
 	}
-	return rt[fmt.Sprintf("%s", servercode)].QuickLoginUrl, rt[fmt.Sprintf("%s", servercode)].GameUrl, nil
 
+	selected, ok := rt[servercode]
+	if !ok || selected.QuickLoginUrl == "" || selected.GameUrl == "" {
+		return "", "", errors.New("server code not found: " + servercode)
+	}
+	return selected.QuickLoginUrl, selected.GameUrl, nil
+}
+
+func serverURL(entry []interface{}, pathIndex int) string {
+	if len(entry) <= pathIndex {
+		return ""
+	}
+	base, _ := entry[1].(string)
+	path, _ := entry[pathIndex].(string)
+	if base == "" || path == "" {
+		return ""
+	}
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+func zoneNumber(name string) int {
+	n := 0
+	last := 0
+	inDigits := false
+	for _, r := range name {
+		if r >= '0' && r <= '9' {
+			if !inDigits {
+				n = 0
+				inDigits = true
+			}
+			n = n*10 + int(r-'0')
+			continue
+		}
+		if inDigits {
+			last = n
+			inDigits = false
+		}
+	}
+	if inDigits {
+		last = n
+	}
+	return last
 }

--- a/loginutil/loginServer.go
+++ b/loginutil/loginServer.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -41,13 +42,27 @@ func ReqLogin() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	reqUrl := `http://ptlogin.4399.com/ptlogin/login.do`
+	reqUrl := `http://ptlogin.4399.com/ptlogin/login.do?v=1`
 	reqBody := fmt.Sprintf("username=%s&password=%s&sec=1", user, url.QueryEscape(string(encryptPass)))
-	resp, err := Util.ReqPostData(reqUrl, reqBody)
+	req, err := http.NewRequest(http.MethodPost, reqUrl, strings.NewReader(reqBody))
 	if err != nil {
 		return "", err
 	}
-	Pauth := getCookieByName(resp.Response().Cookies(), "Pauth")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", "http://ptlogin.4399.com")
+	req.Header.Set("Referer", "http://ptlogin.4399.com/ptlogin/loginFrame.do?postLoginHandler=default&displayMode=popup&appId=www_home")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	Pauth := getCookieByName(resp.Cookies(), "Pauth")
+	if Pauth == "" {
+		return "", fmt.Errorf("ReqLogin empty Pauth, status=%d", resp.StatusCode)
+	}
 	return Pauth, nil
 }
 

--- a/test1/main_test.go
+++ b/test1/main_test.go
@@ -30,10 +30,10 @@ func Test_q(t *testing.T) {
 }
 
 func Test_qa(t *testing.T) {
-	viper.SetConfigFile("../config/config.yaml") // 指定配置文件
-	viper.AddConfigPath("./")                    // 指定查找配置文件的路径
-	err := viper.ReadInConfig()                  // 读取配置信息
-	if err != nil {                              // 读取配置信息失败
+	viper.SetConfigFile("../app/config/config.yaml") // 指定配置文件
+	viper.AddConfigPath("./")                        // 指定查找配置文件的路径
+	err := viper.ReadInConfig()                      // 读取配置信息
+	if err != nil {                                  // 读取配置信息失败
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))
 	}
 

--- a/utils/lz-string.go
+++ b/utils/lz-string.go
@@ -302,11 +302,11 @@ func getString(last string, data *dataStruct) (string, bool, error) {
 	c := readBits(data.numBits, data)
 	switch c {
 	case 0:
-		str := string(readBits(8, data))
+		str := string(rune(readBits(8, data)))
 		appendValue(data, str)
 		return str, false, nil
 	case 1:
-		str := string(readBits(16, data))
+		str := string(rune(readBits(16, data)))
 		appendValue(data, str)
 		return str, false, nil
 	case 2:


### PR DESCRIPTION
﻿## 概括
- 将老乞丐提醒的推送方式从 WxPusher 切换为 QQ 机器人 API，推送目标通过环境变量和区服映射配置控制。
- 添加序列化作业执行，避免定时任务重叠运行；启动时先完成引导检查，7:30 增加晨间自检通知。
- 扩展 H5 区服配置，补充更多新区服账号与 Topic 映射，并将区服选择改为动态解析，减少后续手工维护成本。
- 新增 `cmd/listservers` 区服列表辅助命令，用于快速检查当前登录接口可识别的区服代码。
- QQ 推送逻辑支持分群、私聊、统一群和 JSON 映射文件，便于和现有官方区、混服、暴走、H5、苹果区群映射配置配合使用。

## 验证
- `go test ./...`
